### PR TITLE
Extend config file

### DIFF
--- a/src/data/config.json
+++ b/src/data/config.json
@@ -1,6 +1,10 @@
 {
   "title": "Kratos Boilerplate",
   "description": "A simple and fast boilerplate for static projects using Gulp, Pug, Stylus and PostCSS",
+  "mobile": {
+  	"theme_color": "#ffffff",
+  	"mask_icon_color": "#5bbad5"
+  },
   "social": {
   	"twitter": {
   		"card": "photo",

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -1,6 +1,21 @@
 {
   "title": "Kratos Boilerplate",
   "description": "A simple and fast boilerplate for static projects using Gulp, Pug, Stylus and PostCSS",
+  "social": {
+  	"twitter": {
+  		"card": "photo",
+  		"site": "",
+  		"url": "",
+  		"title": "",
+  		"image": ""
+  	},
+  	"open_graph": {
+  		"title": "",
+  		"description": "",
+  		"image": "",
+  		"url": ""
+  	}
+  },
   "analytics": {
   	"ga": "UA-000000-0"
   }

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -28,7 +28,7 @@ html
     link(rel='apple-touch-icon' sizes='180x180' href='/favicon/apple-touch-icon.png')
     link(rel='icon' type='image/png' href='/favicon/favicon-32x32.png' sizes='32x32')
     link(rel='icon' type='image/png' href='/favicon/favicon-16x16.png' sizes='16x16')
-    link(rel='manifest' href='/manifest.json')
+    //link(rel='manifest' href='/manifest.json')
     link(rel='mask-icon' href='/favicon/safari-pinned-tab.svg' color='#5bbad5')
     meta(name='apple-mobile-web-app-title' content='#{config.title}')
     meta(name='application-name' content='#{config.title}')

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -15,7 +15,7 @@ html
     meta(property='og:description' content=config.social.open_graph.description)
     meta(property='og:image' content=config.social.open_graph.image)
     meta(property='og:url' content=config.social.open_graph.url)
-    
+
     meta(name='twitter:card' content=config.social.twitter.card)
     meta(name='twitter:site' content=config.social.twitter.site)
     meta(name='twitter:title' content=config.social.twitter.title)
@@ -30,10 +30,10 @@ html
     link(rel='icon' type='image/png' href='/favicon/favicon-32x32.png' sizes='32x32')
     link(rel='icon' type='image/png' href='/favicon/favicon-16x16.png' sizes='16x16')
     //link(rel='manifest' href='/manifest.json')
-    link(rel='mask-icon' href='/favicon/safari-pinned-tab.svg' color='#5bbad5')
+    link(rel='mask-icon' href='/favicon/safari-pinned-tab.svg' color=config.mobile.mask_icon_color)
     meta(name='apple-mobile-web-app-title' content=config.title)
     meta(name='application-name' content=config.title)
-    meta(name='theme-color' content='#ffffff')
+    meta(name='theme-color' content=config.mobile.theme_color)
 
     //- ==================================================
     //- Stylesheets

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -30,8 +30,8 @@ html
     link(rel='icon' type='image/png' href='/favicon/favicon-16x16.png' sizes='16x16')
     //link(rel='manifest' href='/manifest.json')
     link(rel='mask-icon' href='/favicon/safari-pinned-tab.svg' color='#5bbad5')
-    meta(name='apple-mobile-web-app-title' content='#{config.title}')
-    meta(name='application-name' content='#{config.title}')
+    meta(name='apple-mobile-web-app-title' content=config.title)
+    meta(name='application-name' content=config.title)
     meta(name='theme-color' content='#ffffff')
 
     //- ==================================================

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -11,15 +11,16 @@ html
     //- Essential Meta Tags for Social Media
     //- ==================================================
 
-    meta(property='og:title' content='')
-    meta(property='og:description' content='')
-    meta(property='og:image' content='')
-    meta(property='og:url' content='')
-    meta(name='twitter:card' content='photo')
-    meta(name='twitter:site' content='')
-    meta(name='twitter:title' content='')
-    meta(name='twitter:image' content='')
-    meta(name='twitter:url' content='')
+    meta(property='og:title' content=config.social.open_graph.title)
+    meta(property='og:description' content=config.social.open_graph.description)
+    meta(property='og:image' content=config.social.open_graph.image)
+    meta(property='og:url' content=config.social.open_graph.url)
+    
+    meta(name='twitter:card' content=config.social.twitter.card)
+    meta(name='twitter:site' content=config.social.twitter.site)
+    meta(name='twitter:title' content=config.social.twitter.title)
+    meta(name='twitter:image' content=config.social.twitter.image)
+    meta(name='twitter:url' content=config.social.twitter.url)
 
     //- ==================================================
     //- Webapp


### PR DESCRIPTION
Allow to easily update the meta tags from the configuration file:

Added to the config.json file:

 * `social.twitter`
 * `social.open_graph`
 * `mobile.theme_color`
 * `mobile.mask_icon_color`

____

Additional changes:

 * Fixed `config.title` rendering in the `apple-mobile-web-app-title` and `application-name` meta tags
 * Commented `manifest.json` meta tag (`manifest.json` not found)
 * Updated `index.pug` file to support the new config file
