### PR TITLE
Ensuring absolute path for assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ const baseWebpack = {
     app: './src/app.js'
   },
   output: {
+    publicPath: '/',
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].bundle.js'
   },


### PR DESCRIPTION
On some servers (Netlify in my case), styles will not load and return an error complaining:
`...[filename]is not a supported stylesheet MIME type, and strict MIME checking is enabled.`

The [fix](https://stackoverflow.com/a/34628034) is apparently setting a baseURL in the meta tag (this didn't work for me) or setting the `publicPath: '/'` to server root in the webpack config. The latter seemed to work for me.